### PR TITLE
Update to AGP 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Let's summarize.
 **Cons**
 1. Cannot screenshot Activities or Fragments
 2. Rendering problems
-   1. Incorrect screenshots for UI components that use View.animate() or ObjectAnimator.ofPropertyValuesHolder()
+   1. Incorrect screenshots for UI components that call View.animate() or ObjectAnimator.ofPropertyValuesHolder() several times.
    2. Only renders what the Compose @Previews can display
 3. Fragile to AGP & Jetpack Compose updates
 4. No support for Pseudolocales

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    namespace 'com.example.road.to.effective.snapshot.testing'
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.road.to.effective.snapshot.testing"
-        minSdkVersion 23
-        targetSdkVersion 33
+        minSdk 23
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -41,11 +42,11 @@ android {
     testOptions {
         animationsDisabled = true
     }
-
     // required for compatibility with shot
     packagingOptions {
-        exclude 'META-INF/AL2.0'
-        exclude "META-INF/LGPL2.1"
+        resources {
+            excludes += ['META-INF/AL2.0', 'META-INF/LGPL2.1']
+        }
     }
 
     buildFeatures {
@@ -54,7 +55,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 }
 
@@ -64,17 +65,17 @@ dependencies {
     implementation project(':recyclerviewscreen')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0-alpha01'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
 
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.fragment:fragment-ktx:1.5.5'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation 'androidx.fragment:fragment-ktx:1.6.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
     implementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.1'
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-ui-ktx:2.6.0"
 
     // Jetpack Compose
     implementation platform('androidx.compose:compose-bom:2022.10.00')
@@ -89,8 +90,8 @@ dependencies {
     implementation "androidx.compose.runtime:runtime-livedata"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
 
-    implementation "androidx.navigation:navigation-compose:2.5.3"
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-compose:2.6.0"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.6.0"
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.road.to.effective.snapshot.testing">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission
         android:name="android.permission.CHANGE_CONFIGURATION"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.road.to.effective.snapshot.testing">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,20 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.8.0"
+    ext.kotlin_version = "1.8.21"
     repositories {
         google()
         mavenCentral()
         mavenLocal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.3.1"
+        classpath 'com.android.tools.build:gradle:8.2.0-alpha12'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1"
 
         // screenshot testing plugins
         // noinspection GradleDependency
-        classpath('app.cash.paparazzi:paparazzi-gradle-plugin:1.2.0'){
-            because "1.3.0 requires AGP 8.0.0 and it is not compatible with Shot"
-        }
+        classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:1.3.1'
         classpath 'com.karumi:shot:6.0.0'
         classpath 'com.dropbox.dropshots:dropshots-gradle-plugin:0.4.0'
         classpath 'io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.4.0-alpha-5'

--- a/dialogs/build.gradle
+++ b/dialogs/build.gradle
@@ -5,13 +5,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.dialogs'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -33,11 +31,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/dialogs/dropshots/build.gradle
+++ b/dialogs/dropshots/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.dialogs.dropshots'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing.dialogs.dropshots"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/bitmap/DeleteDialogBitmapTest.kt
+++ b/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/bitmap/DeleteDialogBitmapTest.kt
@@ -27,6 +27,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/dialog/parameterized/DeleteDialogWithParameterizedRunnerTest.kt
+++ b/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/dialog/parameterized/DeleteDialogWithParameterizedRunnerTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/dialog/parameterized/DeleteDialogWithTestParameterInjectorTest.kt
+++ b/dialogs/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/dropshots/dialog/parameterized/DeleteDialogWithTestParameterInjectorTest.kt
@@ -22,6 +22,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :dialogs:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/dialogs/paparazzi/build.gradle
+++ b/dialogs/paparazzi/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.dialogs.paparazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -35,6 +33,16 @@ android {
         jvmTarget = '1.8'
     }
 
+    // Jetpack Compose required for Accessibility tests...
+    buildFeatures {
+        // Enables Jetpack Compose for this module
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.4.7'
+    }
+
     // Enable running tests in parallel
     testOptions {
         unitTests.all {
@@ -49,4 +57,9 @@ dependencies {
     implementation project(':dialogs')
 
     testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.8'
+
+    // Jetpack Compose required for Accessibility tests...
+    implementation platform('androidx.compose:compose-bom:2023.03.00')
+    implementation "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui"
 }

--- a/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/DeleteDialogWithParameterizedRunnerTest.kt
+++ b/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/DeleteDialogWithParameterizedRunnerTest.kt
@@ -2,6 +2,8 @@ package com.example.road.to.effective.snapshot.testing.dialogs.paparazzi
 
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.androidHome
+import app.cash.paparazzi.detectEnvironment
 import com.example.road.to.effective.snapshot.testing.dialogs.DialogBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -36,13 +38,16 @@ class DeleteDialogParameterizedHappyPathTest(
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             screenWidth = testItem.deleteItem.screenWidth.widthInPx,
             nightMode = testItem.deleteItem.deviceConfig.nightMode,
             fontScale = testItem.deleteItem.deviceConfig.fontScale,
         ),
-        showSystemUi = false,
         theme = "Theme.RoadToEffectiveSnapshotTesting",
+        // Needed to avoid crashes due to compileSdk 34
+        environment = detectEnvironment().copy(
+            platformDir = "${androidHome()}/platforms/android-33",
+            compileSdkVersion = 33
+        ),
     )
 
     @Test
@@ -75,12 +80,10 @@ class DeleteDialogParameterizedUnhappyPathTest(
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             screenWidth = testItem.deleteItem.screenWidth.widthInPx,
             nightMode = testItem.deleteItem.deviceConfig.nightMode,
             fontScale = testItem.deleteItem.deviceConfig.fontScale,
         ),
-        showSystemUi = false,
         theme = "Theme.RoadToEffectiveSnapshotTesting",
     )
 

--- a/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/DeleteDialogWithTestParameterInjectorTest.kt
+++ b/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/DeleteDialogWithTestParameterInjectorTest.kt
@@ -2,6 +2,8 @@ package com.example.road.to.effective.snapshot.testing.dialogs.paparazzi
 
 import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_5
 import app.cash.paparazzi.Paparazzi
+import app.cash.paparazzi.androidHome
+import app.cash.paparazzi.detectEnvironment
 import com.example.road.to.effective.snapshot.testing.dialogs.DialogBuilder
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
@@ -29,13 +31,16 @@ class DeleteDialogTestParameterHappyPathTest(
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = PIXEL_5.copy(
-            softButtons = false,
             screenWidth = testItem.deleteItem.screenWidth.widthInPx,
             nightMode = testItem.deleteItem.deviceConfig.nightMode,
             fontScale = testItem.deleteItem.deviceConfig.fontScale,
         ),
-        showSystemUi = false,
         theme = "Theme.RoadToEffectiveSnapshotTesting",
+        // Needed to avoid crashes due to compileSdk 34
+        environment = detectEnvironment().copy(
+            platformDir = "${androidHome()}/platforms/android-33",
+            compileSdkVersion = 33
+        ),
     )
 
     @Test
@@ -60,12 +65,10 @@ class DeleteDialogTestParameterUnhappyPathTest(
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = PIXEL_5.copy(
-            softButtons = false,
             screenWidth = testItem.deleteItem.screenWidth.widthInPx,
             nightMode = testItem.deleteItem.deviceConfig.nightMode,
             fontScale = testItem.deleteItem.deviceConfig.fontScale,
         ),
-        showSystemUi = false,
         theme = "Theme.RoadToEffectiveSnapshotTesting",
     )
 

--- a/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/accessibility/AccessibilityTest.kt
+++ b/dialogs/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/paparazzi/accessibility/AccessibilityTest.kt
@@ -3,6 +3,8 @@ package com.example.road.to.effective.snapshot.testing.dialogs.paparazzi.accessi
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
+import app.cash.paparazzi.androidHome
+import app.cash.paparazzi.detectEnvironment
 import com.example.road.to.effective.snapshot.testing.dialogs.DialogBuilder
 import com.example.road.to.effective.snapshot.testing.dialogs.R
 import com.example.road.to.effective.snapshot.testing.dialogs.paparazzi.itemArray
@@ -21,14 +23,18 @@ class AccessibilityTest {
     @get:Rule
     val paparazzi = Paparazzi(
         // For Accessibility, better to use devices in landscape with Paparazzi
-        deviceConfig = DeviceConfig.NEXUS_5_LAND.copy(softButtons = false),
-        showSystemUi = false,
+        deviceConfig = DeviceConfig.NEXUS_5_LAND,
         theme = "Theme.RoadToEffectiveSnapshotTesting",
+        // Needed to avoid crashes due to compileSdk 34
+        environment = detectEnvironment().copy(
+            platformDir = "${androidHome()}/platforms/android-33",
+            compileSdkVersion = 33
+        ),
         renderExtensions = setOf(AccessibilityRenderExtension())
     )
 
     @Test
-    fun snapDialogWithAccessibility() {
+    fun snapWithAccessibility() {
         val dialog =
             DialogBuilder.buildDeleteDialog(
                 ctx = paparazzi.context,

--- a/dialogs/roborazzi/build.gradle
+++ b/dialogs/roborazzi/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.dialogs.roborazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/roborazzi/accessibility/AccessibilityTest.kt
+++ b/dialogs/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/dialogs/roborazzi/accessibility/AccessibilityTest.kt
@@ -60,7 +60,7 @@ class AccessibilityTest {
     @GraphicsMode(NATIVE)
     @Config(sdk = [30])
     @Test
-    fun snapDialog() {
+    fun snapWithAccessibility() {
         val activity = activityScenarioForViewRule.activity
 
         val dialogView = waitForMeasuredView {

--- a/dialogs/shot/build.gradle
+++ b/dialogs/shot/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.dialogs.shot'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }

--- a/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/bitmap/DeleteDialogBitmapTest.kt
+++ b/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/bitmap/DeleteDialogBitmapTest.kt
@@ -25,6 +25,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/parameterized/DeleteDialogWithParameterizedRunnerTest.kt
+++ b/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/parameterized/DeleteDialogWithParameterizedRunnerTest.kt
@@ -20,6 +20,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest -Precord
  * 2. Verify:
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/parameterized/DeleteDialogWithTestParameterInjectorTest.kt
+++ b/dialogs/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/dialogs/shot/parameterized/DeleteDialogWithTestParameterInjectorTest.kt
@@ -22,6 +22,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredDialog
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest -Precord
  * 2. Verify:
  *    ./gradlew :dialogs:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.DialogTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,11 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4608m -Dfile.encoding=UTF-8
+
+# All screenshot testing library plugins support configuration cache
+# I enable it by default to speed up its execution
+org.gradle.configuration-cache=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -18,3 +23,6 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.jetifier.ignorelist=android-base-common,common
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 02 17:31:19 CET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/lazycolumnscreen/build.gradle
+++ b/lazycolumnscreen/build.gradle
@@ -5,13 +5,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -37,20 +35,20 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 }
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0-alpha01'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation 'androidx.fragment:fragment-ktx:1.5.5'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.fragment:fragment-ktx:1.6.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
     implementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.1'
-    implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-ui-ktx:2.6.0"
 
     // Jetpack Compose
     implementation platform('androidx.compose:compose-bom:2023.03.00')
@@ -64,8 +62,8 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling"
     implementation "androidx.compose.runtime:runtime-livedata"
 
-    implementation "androidx.navigation:navigation-compose:2.5.3"
-    implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
+    implementation "androidx.navigation:navigation-compose:2.6.0"
+    implementation "androidx.navigation:navigation-fragment-ktx:2.6.0"
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/lazycolumnscreen/crosslibrary/build.gradle
+++ b/lazycolumnscreen/crosslibrary/build.gradle
@@ -50,14 +50,12 @@ if (screenshotLibrary(ROBORAZZI)) {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen.crosslibrary'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         // make gradle constants available in Tests via BuildConfig to make changes consistent
         // among build and test files
@@ -97,7 +95,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 
     testOptions {
@@ -136,18 +134,18 @@ dependencies {
     implementation project(':lazycolumnscreen')
     implementation project(':testannotations')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta03')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta04')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.0.0-beta03')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.0.0-beta04')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.0.0-beta03')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.0.0-beta04')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0-beta03')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.0.0-beta03')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:sharedtest-roborazzi:2.0.0-beta03')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0-beta04')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.0.0-beta04')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:sharedtest-roborazzi:2.0.0-beta04')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.0.0-beta03')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:sharedtest-paparazzi:2.0.0-beta03')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.0.0-beta04')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:sharedtest-paparazzi:2.0.0-beta04')
 
     // Jetpack Compose
     debugImplementation platform('androidx.compose:compose-bom:2023.03.00')

--- a/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/LaunchEffectSnackbarComposableTest.kt
+++ b/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/LaunchEffectSnackbarComposableTest.kt
@@ -8,6 +8,9 @@ import com.example.road.to.effective.snapshot.testing.testannotations.Composable
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import sergio.sastre.uitesting.sharedtest.paparazzi.PaparazziConfig
+import sergio.sastre.uitesting.sharedtest.paparazzi.wrapper.RenderingMode
+import sergio.sastre.uitesting.shot.ShotConfig
 import sergio.sastre.uitesting.utils.crosslibrary.config.ScreenshotConfig
 import sergio.sastre.uitesting.utils.crosslibrary.runners.CrossLibraryScreenshotTestRunner
 
@@ -35,6 +38,8 @@ class SnackbarComposableTest {
     @get:Rule
     val screenshotRule =
         defaultCrossLibraryScreenshotTestRule(ScreenshotConfig())
+            .configure(ShotConfig(/*no pixel copy -> otherwise Shot cannot render Snackbar*/))
+            .configure(PaparazziConfig(renderingMode = RenderingMode.NORMAL))
 
     @ComposableTest
     @Test

--- a/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/utils/CrossLibraryScreenshotTestRule.kt
+++ b/lazycolumnscreen/crosslibrary/src/sharedTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/crosslibrary/utils/CrossLibraryScreenshotTestRule.kt
@@ -7,32 +7,40 @@ import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.crosslibr
 import sergio.sastre.uitesting.dropshots.DropshotsConfig
 import sergio.sastre.uitesting.sharedtest.paparazzi.PaparazziConfig
 import sergio.sastre.uitesting.sharedtest.paparazzi.wrapper.DeviceConfig
+import sergio.sastre.uitesting.sharedtest.paparazzi.wrapper.RenderingMode
 import sergio.sastre.uitesting.sharedtest.roborazzi.RoborazziConfig
 import sergio.sastre.uitesting.sharedtest.roborazzi.wrapper.screen.DeviceScreen
 import sergio.sastre.uitesting.shot.ShotConfig
 import sergio.sastre.uitesting.utils.crosslibrary.config.BitmapCaptureMethod.PixelCopy
 import sergio.sastre.uitesting.utils.crosslibrary.config.ScreenshotConfig
-import sergio.sastre.uitesting.utils.crosslibrary.testrules.ScreenshotTestRule
-import sergio.sastre.uitesting.utils.crosslibrary.testrules.SharedScreenshotTestRule
+import sergio.sastre.uitesting.utils.crosslibrary.testrules.ScreenshotTestRuleForComposable
+import sergio.sastre.uitesting.utils.crosslibrary.testrules.SharedScreenshotTestRuleForComposable
 import java.io.File
 
 /**
- * A [SharedScreenshotTestRule] that decides which library runs the instrumented screenshot tests
+ * A [SharedScreenshotTestRuleForComposable] that decides which library runs the instrumented screenshot tests
  * based on the -PscreenshotLibrary argument passed via command line.
+ *
+ * It required some extra configuration in the gradle file
+ * Take a look at the :lazycolumnscreen:crosslibrary gradle file to see how it is configured
  */
 
 class CrossLibraryScreenshotTestRule(
     override val config: ScreenshotConfig,
-) : SharedScreenshotTestRule(config) {
+) : SharedScreenshotTestRuleForComposable(config) {
 
-    override fun getInstrumentedScreenshotTestRule(config: ScreenshotConfig): ScreenshotTestRule =
+    override fun getInstrumentedScreenshotTestRule(
+        config: ScreenshotConfig,
+    ): ScreenshotTestRuleForComposable =
         when (instrumentationScreenshotLibraryName) {
             BuildConfig.SHOT -> shotScreenshotTestRule
             BuildConfig.DROPSHOTS -> dropshotsScreenshotTestRule
             else -> throw ScreenshotLibraryArgumentMissingException()
         }
 
-    override fun getJvmScreenshotTestRule(config: ScreenshotConfig): ScreenshotTestRule =
+    override fun getJvmScreenshotTestRule(
+        config: ScreenshotConfig,
+    ): ScreenshotTestRuleForComposable =
         when (jvmScreenshotLibraryName) {
             BuildConfig.PAPARAZZI -> paparazziScreenshotTestRule
             BuildConfig.ROBORAZZI -> roborazziScreenshotTestRule
@@ -54,7 +62,7 @@ class CrossLibraryScreenshotTestRule(
 
  fun defaultCrossLibraryScreenshotTestRule(
      config: ScreenshotConfig,
- ): ScreenshotTestRule =
+ ): ScreenshotTestRuleForComposable =
     CrossLibraryScreenshotTestRule(config)
         // Optional: configure for the libraries you use
         .configure(
@@ -69,6 +77,7 @@ class CrossLibraryScreenshotTestRule(
         ).configure(
             PaparazziConfig(
                 deviceConfig = DeviceConfig.NEXUS_4,
+                renderingMode = RenderingMode.SHRINK,
             )
         ).configure(
             RoborazziConfig(

--- a/lazycolumnscreen/dropshots/build.gradle
+++ b/lazycolumnscreen/dropshots/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen.dropshots'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -50,7 +48,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 }
 
@@ -59,7 +57,7 @@ dependencies {
     implementation project(':testannotations')
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation "androidx.navigation:navigation-compose:2.5.3"
+    implementation "androidx.navigation:navigation-compose:2.6.0"
 
     // Jetpack Compose
     androidTestImplementation platform('androidx.compose:compose-bom:2023.03.00')

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/activity/CoffeeDrinkComposeActivityTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/activity/CoffeeDrinkComposeActivityTest.kt
@@ -28,6 +28,9 @@ import sergio.sastre.uitesting.utils.utils.waitForActivity
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinkComposableToBitmapTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinkComposableToBitmapTest.kt
@@ -28,6 +28,9 @@ import sergio.sastre.uitesting.utils.utils.waitForComposeView
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinkComposeActivityToBitmapToTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinkComposeActivityToBitmapToTest.kt
@@ -23,6 +23,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinksComposeFragmentToBitmapTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/bitmap/CoffeeDrinksComposeFragmentToBitmapTest.kt
@@ -23,6 +23,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/CoffeeDrinkAppBarComposableTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/CoffeeDrinkAppBarComposableTest.kt
@@ -29,6 +29,9 @@ import sergio.sastre.uitesting.utils.utils.waitForComposeView
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/LaunchEffectSnackbarComposableTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/LaunchEffectSnackbarComposableTest.kt
@@ -18,6 +18,9 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 class SnackbarComposableTest {
 

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
@@ -22,6 +22,9 @@ import sergio.sastre.uitesting.utils.utils.waitForComposeView
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/compose/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
@@ -23,6 +23,9 @@ import sergio.sastre.uitesting.utils.utils.waitForComposeView
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/fragment/CoffeeDrinksComposeFragmentTest.kt
+++ b/lazycolumnscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/dropshots/fragment/CoffeeDrinksComposeFragmentTest.kt
@@ -25,6 +25,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.waitForFragment
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/paparazzi/build.gradle
+++ b/lazycolumnscreen/paparazzi/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen.paparazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -41,7 +39,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 
     // Enable running tests in parallel

--- a/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/CoffeeDrinkAppBarComposableTest.kt
+++ b/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/CoffeeDrinkAppBarComposableTest.kt
@@ -26,7 +26,6 @@ class CoffeeDrinkAppBarComposableHappyPathTest {
         Paparazzi(
             deviceConfig =
             DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = NightMode.NOTNIGHT,
                 fontScale = 1.0f,
                 locale = "en",
@@ -51,7 +50,6 @@ class CoffeeDrinkAppBarComposableUnhappyPathTest {
     val paparazzi =
         Paparazzi(
             deviceConfig = DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = NightMode.NIGHT,
                 fontScale = 1.3f,
                 locale = "en",

--- a/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/LaunchEffectSnackbarComposableTest.kt
+++ b/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/LaunchEffectSnackbarComposableTest.kt
@@ -1,6 +1,7 @@
 package com.example.road.to.effective.snapshot.testing.lazycolumnscreen.paparazzi
 
 import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.InstantAnimationsRule
 import app.cash.paparazzi.Paparazzi
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.ActionNotSupportedSnackbar
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.AppTheme
@@ -19,7 +20,7 @@ class SnackbarComposableTest {
 
     @get:Rule
     val paparazzi =
-        Paparazzi(deviceConfig = DeviceConfig.PIXEL_5.copy(softButtons = false))
+        Paparazzi(deviceConfig = DeviceConfig.PIXEL_5)
 
     @Test
     fun snapComposable() {

--- a/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/accessibility/AccessibilityTest.kt
+++ b/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/accessibility/AccessibilityTest.kt
@@ -1,8 +1,12 @@
 package com.example.road.to.effective.snapshot.testing.lazycolumnscreen.paparazzi.accessibility
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.ui.Modifier
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
 import app.cash.paparazzi.accessibility.AccessibilityRenderExtension
+import com.android.ide.common.rendering.api.SessionParams
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.AppTheme
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.CoffeeDrinkAppBar
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.CoffeeDrinkList
@@ -22,24 +26,29 @@ class AccessibilityTest {
     val paparazzi =
         Paparazzi(
             // For Accessibility, better to use devices in landscape with Paparazzi
-            deviceConfig = DeviceConfig.NEXUS_5_LAND.copy(softButtons = false),
+            deviceConfig = DeviceConfig.NEXUS_5_LAND,
+            renderingMode = SessionParams.RenderingMode.V_SCROLL,
             renderExtensions = setOf(AccessibilityRenderExtension())
         )
 
     @Test
-    fun snapCoffeeDrinkAppBarComposableWithAccessibility() {
+    fun snapCoffeeDrinkAppBarWithAccessibility() {
         paparazzi.snapshot(name = "CoffeeDrinkAppBarComposable_Accessibility") {
             AppTheme {
-                CoffeeDrinkAppBar()
+                Box(modifier = Modifier.wrapContentSize()) {
+                    CoffeeDrinkAppBar()
+                }
             }
         }
     }
 
     @Test
-    fun snapCoffeeDrinkListComposableWithAccessibility() {
+    fun snapCoffeeDrinkListWithAccessibility() {
         paparazzi.snapshot(name = "CoffeeDrinkListComposable_Accessibility") {
             AppTheme {
-                CoffeeDrinkList(coffeeDrink = coffeeDrink)
+                Box(modifier = Modifier.wrapContentSize()) {
+                    CoffeeDrinkList(coffeeDrink = coffeeDrink)
+                }
             }
         }
     }

--- a/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
+++ b/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
@@ -40,7 +40,6 @@ class CoffeeDrinkListComposableParameterizedHappyPathTest(
     val paparazzi =
         Paparazzi(
             deviceConfig = DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = testItem.item.nightMode,
                 fontScale = testItem.item.fontScale,
                 locale = testItem.item.locale,
@@ -74,7 +73,6 @@ class CoffeeDrinkListComposableParameterizedUnhappyPathTest(
     @get:Rule
     val paparazzi = Paparazzi(
         deviceConfig = DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             nightMode = testItem.item.nightMode,
             fontScale = testItem.item.fontScale,
             locale = testItem.item.locale,

--- a/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
+++ b/lazycolumnscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/paparazzi/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
@@ -35,7 +35,6 @@ class CoffeeDrinkListComposableTestParameterHappyPathTest(
     val paparazzi =
         Paparazzi(
             deviceConfig = DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = testItem.item.nightMode,
                 fontScale = testItem.item.fontScale,
                 locale = testItem.item.locale,
@@ -64,7 +63,6 @@ class CoffeeDrinkListComposableTestParameterUnhappyPathTest(
     val paparazzi =
         Paparazzi(
             deviceConfig = DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = testItem.item.nightMode,
                 fontScale = testItem.item.fontScale,
                 locale = testItem.item.locale,

--- a/lazycolumnscreen/roborazzi/build.gradle
+++ b/lazycolumnscreen/roborazzi/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen.roborazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -42,7 +40,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 
     testOptions {

--- a/lazycolumnscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/roborazzi/accessibility/AccessibilityTest.kt
+++ b/lazycolumnscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/roborazzi/accessibility/AccessibilityTest.kt
@@ -2,6 +2,7 @@ package com.example.road.to.effective.snapshot.testing.lazycolumnscreen.roborazz
 
 import androidx.compose.ui.test.onRoot
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.AppTheme
+import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.CoffeeDrinkAppBar
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.CoffeeDrinkList
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.roborazzi.compose.parameterized.HappyPathTestItem
 import com.example.road.to.effective.snapshot.testing.lazycolumnscreen.roborazzi.compose.parameterized.coffeeDrink
@@ -58,7 +59,26 @@ class AccessibilityTest {
     @GraphicsMode(NATIVE)
     @Config(sdk = [30])
     @Test
-    fun snapComposableWithAccessibility() {
+    fun snapCoffeeDrinkAppBarWithAccessibility() {
+        activityScenarioForComposableRule.setContent {
+            AppTheme {
+                CoffeeDrinkAppBar()
+            }
+
+        }
+
+        activityScenarioForComposableRule.composeRule
+            .onRoot()
+            .captureRoboImage(
+                filePath = filePath("CoffeeDrinkAppBarComposable_Accessibility"),
+                roborazziOptions = roborazziAccessibilityOptions,
+            )
+    }
+
+    @GraphicsMode(NATIVE)
+    @Config(sdk = [30])
+    @Test
+    fun snapCoffeeDrinkListWithAccessibility() {
         activityScenarioForComposableRule.setContent {
             AppTheme {
                 CoffeeDrinkList(coffeeDrink = coffeeDrink)

--- a/lazycolumnscreen/shot/build.gradle
+++ b/lazycolumnscreen/shot/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.lazycolumnscreen.shot'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }
@@ -51,7 +49,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.7'
     }
 }
 
@@ -65,7 +63,7 @@ dependencies {
     implementation project(':lazycolumnscreen')
 
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation "androidx.navigation:navigation-compose:2.5.3"
+    implementation 'androidx.navigation:navigation-compose:2.6.0'
 
     // Jetpack Compose
     androidTestImplementation platform('androidx.compose:compose-bom:2023.03.00')

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/activity/CoffeeDrinkComposeActivityTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/activity/CoffeeDrinkComposeActivityTest.kt
@@ -25,6 +25,9 @@ import sergio.sastre.uitesting.utils.utils.waitForActivity
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinkComposableToBitmapTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinkComposableToBitmapTest.kt
@@ -26,6 +26,9 @@ import sergio.sastre.uitesting.utils.utils.waitForComposeView
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinkComposeActivityToBitmapTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinkComposeActivityToBitmapTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinksComposeFragmentToBitmapTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/bitmap/CoffeeDrinksComposeFragmentToBitmapTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/CoffeeDrinkAppBarComposableTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/CoffeeDrinkAppBarComposableTest.kt
@@ -27,6 +27,9 @@ import sergio.sastre.uitesting.utils.utils.waitForActivity
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/LaunchEffectSnackbarComposableTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/LaunchEffectSnackbarComposableTest.kt
@@ -17,6 +17,9 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 @SdkSuppress(minSdkVersion = 26) // ScreenshotTest.compareScreenshot(rule = ...) requires API 26+
 class SnackbarComposableTest : ScreenshotTest {

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/parameterized/CoffeeDrinkListComposableWithParameterizedRunnerTest.kt
@@ -20,6 +20,9 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/compose/parameterized/CoffeeDrinkListComposableWithTestParameterInjectorTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ComposableTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/fragment/CoffeeDrinksComposeFragmentTest.kt
+++ b/lazycolumnscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/lazycolumnscreen/shot/fragment/CoffeeDrinksComposeFragmentTest.kt
@@ -23,6 +23,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.waitForFragment
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Precord
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/build.gradle
+++ b/recyclerviewscreen/build.gradle
@@ -5,11 +5,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.recyclerviewscreen'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/recyclerviewscreen/dropshots/build.gradle
+++ b/recyclerviewscreen/dropshots/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.recyclerviewscreen.dropshots'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -55,7 +53,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.8'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta03'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta04'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/activity/LanguageTrainingActivityWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/activity/LanguageTrainingActivityWithParameterizedRunnerTest.kt
@@ -20,6 +20,9 @@ import sergio.sastre.uitesting.utils.activityscenario.activityScenarioForActivit
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/activity/LanguageTrainingActivityWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/activity/LanguageTrainingActivityWithTestParameterInjectorTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.activityscenario.activityScenarioForActivit
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :lazycolumnscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/LanguageTrainingActivityToBitmapTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/LanguageTrainingActivityToBitmapTest.kt
@@ -23,6 +23,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/LanguageTrainingFragmentToBitmapTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/LanguageTrainingFragmentToBitmapTest.kt
@@ -22,6 +22,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/MemoriseViewHolderToBitmapTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/bitmap/MemoriseViewHolderToBitmapTest.kt
@@ -27,6 +27,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/fragment/LanguageTrainingFragmentWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/fragment/LanguageTrainingFragmentWithParameterizedRunnerTest.kt
@@ -19,6 +19,9 @@ import org.junit.runners.Parameterized
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/fragment/LanguageTrainingFragmentWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/fragment/LanguageTrainingFragmentWithTestParameterInjectorTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfigurat
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/recyclerview/FullRecyclerViewTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/recyclerview/FullRecyclerViewTest.kt
@@ -5,12 +5,12 @@ import com.dropbox.dropshots.Dropshots
 import com.dropbox.dropshots.ThresholdValidator
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.R
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.dropshots.utils.DropshotsAPI29Fix
-import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.dropshots.utils.drawFullScrollableToBitmap
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.mvvm.LanguageTrainingFragment
 import com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest
 import org.junit.Rule
 import org.junit.Test
 import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfiguratorRule
+import sergio.sastre.uitesting.utils.utils.drawFullScrollableToBitmap
 
 /**
  * Execute the command below to run only RecyclerViewTests
@@ -18,6 +18,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfigurat
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 class FullRecyclerViewTest {
 

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/utils/TestUtils.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/utils/TestUtils.kt
@@ -1,9 +1,0 @@
-package com.example.road.to.effective.snapshot.testing.recyclerviewscreen.dropshots.utils
-
-import android.graphics.Bitmap
-import android.view.View
-import androidx.core.view.drawToBitmap
-import sergio.sastre.uitesting.utils.utils.waitForMeasuredView
-
-fun View.drawFullScrollableToBitmap(): Bitmap =
-    waitForMeasuredView { this }.drawToBitmap()

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/MemoriseViewHolderTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/MemoriseViewHolderTest.kt
@@ -27,6 +27,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/dropshots/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/dropshots/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
@@ -22,6 +22,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Pdropshots.record
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:dropshots:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/paparazzi/build.gradle
+++ b/recyclerviewscreen/paparazzi/build.gradle
@@ -6,13 +6,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.recyclerviewscreen.paparazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -35,6 +33,16 @@ android {
         jvmTarget = '1.8'
     }
 
+    // Jetpack Compose required for Accessibility tests...
+    buildFeatures {
+        // Enables Jetpack Compose for this module
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.4.7'
+    }
+
     // Enable running tests in parallel
     testOptions {
         unitTests.all {
@@ -49,6 +57,11 @@ dependencies {
     implementation project(':recyclerviewscreen')
 
     implementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.1'
+
+    // Jetpack Compose required for Accessibility tests...
+    implementation platform('androidx.compose:compose-bom:2023.03.00')
+    implementation "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui"
 
     testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.8'
 }

--- a/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/accessibility/AccessibilityTest.kt
+++ b/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/accessibility/AccessibilityTest.kt
@@ -28,13 +28,13 @@ class AccessibilityTest {
             //
             // As side effect, this will screenshot a landscape layout. This might differ from the
             // portrait one, as it is the case with R.layout.memorise_row
-            deviceConfig = DeviceConfig.NEXUS_5_LAND.copy(softButtons = false),
+            deviceConfig = DeviceConfig.NEXUS_5_LAND,
             theme = "Theme.RoadToEffectiveSnapshotTesting",
             renderExtensions = setOf(AccessibilityRenderExtension())
         )
 
     @Test
-    fun snapMemoriseViewHolderWithAccessibility() {
+    fun snapMemoriseVHWithAccessibility() {
         val layout = paparazzi.inflate<View>(R.layout.memorise_row)
         val view = MemoriseViewHolder(
             container = layout,
@@ -56,7 +56,7 @@ class AccessibilityTest {
     }
 
     @Test
-    fun snapTrainingViewHolderWithAccessibility() {
+    fun snapTrainingVHWithAccessibility() {
         val trainingTestItem = HappyPathTestItem.HAPPY_EN_WITH_WORDS.item
 
         val layout = paparazzi.inflate<View>(R.layout.training_row)

--- a/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/recyclerview/FullRecyclerView.kt
+++ b/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/recyclerview/FullRecyclerView.kt
@@ -22,12 +22,19 @@ import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.ui.rows
 import org.junit.Rule
 import org.junit.Test
 
+/**
+ * Execute the command below to run only AccessibilityTests
+ * 1. Record:
+ *    ./gradlew :recyclerviewscreen:paparazzi:recordPaparazziDebug --tests '*RecyclerView*'
+ * 2. Verify:
+ *    ./gradlew :recyclerviewscreen:paparazzi:verifyPaparazziDebug --tests '*RecyclerView*'
+ */
 class RecyclerViewTest {
 
     @get:Rule
     val paparazzi =
         Paparazzi(
-            deviceConfig = PIXEL_XL.copy(softButtons = false),
+            deviceConfig = PIXEL_XL,
             theme = "Theme.RoadToEffectiveSnapshotTesting",
             renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )

--- a/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/MemoriseViewHolderTest.kt
+++ b/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/MemoriseViewHolderTest.kt
@@ -30,11 +30,7 @@ class MemoriseViewHolderHappyPathTest {
     @get:Rule
     val paparazzi =
         Paparazzi(
-            deviceConfig = DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
-                locale = "en",
-            ).setPhoneOrientation(PhoneOrientation.LANDSCAPE),
-            showSystemUi = false,
+            deviceConfig = DeviceConfig.PIXEL_5.setPhoneOrientation(PhoneOrientation.LANDSCAPE),
             theme = "Theme.RoadToEffectiveSnapshotTesting",
             renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )
@@ -71,11 +67,8 @@ class MemoriseViewHolderUnhappyPathTest {
         Paparazzi(
             deviceConfig =
             DeviceConfig.PIXEL_5.copy(
-                softButtons = false,
                 nightMode = NightMode.NIGHT,
-                locale = "en",
             ).setPhoneOrientation(PhoneOrientation.LANDSCAPE),
-            showSystemUi = false,
             theme = "Theme.RoadToEffectiveSnapshotTesting",
             renderingMode = SessionParams.RenderingMode.V_SCROLL,
         )

--- a/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
@@ -44,12 +44,10 @@ class TrainingViewHolderParameterizedHappyPathTest(
     val paparazzi = Paparazzi(
         deviceConfig =
         DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             nightMode = deviceConfig.nightMode,
             locale = deviceConfig.locale,
             fontScale = deviceConfig.fontScale,
         ).setPhoneOrientation(deviceConfig.orientation),
-        showSystemUi = false,
         theme = deviceConfig.theme,
         supportsRtl = true, // needed for "ar" locale
         renderingMode = SessionParams.RenderingMode.V_SCROLL,
@@ -89,12 +87,10 @@ class TrainingViewHolderParameterizedUnhappyPathTest(
     val paparazzi = Paparazzi(
         deviceConfig =
         DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             nightMode = deviceConfig.nightMode,
             locale = deviceConfig.locale,
             fontScale = deviceConfig.fontScale,
         ).setPhoneOrientation(deviceConfig.orientation),
-        showSystemUi = false,
         supportsRtl = true, // needed for "ar" locale
         theme = deviceConfig.theme,
         renderingMode = SessionParams.RenderingMode.V_SCROLL,

--- a/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/paparazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/paparazzi/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
@@ -37,12 +37,10 @@ class TrainingViewHolderTestParameterHappyPathTest(
     val paparazzi = Paparazzi(
         deviceConfig =
         DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             nightMode = deviceConfig.nightMode,
             locale = deviceConfig.locale,
             fontScale = deviceConfig.fontScale,
         ).setPhoneOrientation(deviceConfig.orientation),
-        showSystemUi = false,
         theme = deviceConfig.theme,
         supportsRtl = true, // needed for "ar" locale
         renderingMode = SessionParams.RenderingMode.V_SCROLL,
@@ -76,12 +74,10 @@ class TrainingViewHolderTestParameterUnhappyPathTest(
     val paparazzi = Paparazzi(
         deviceConfig =
         DeviceConfig.PIXEL_5.copy(
-            softButtons = false,
             nightMode = deviceConfig.nightMode,
             locale = deviceConfig.locale,
             fontScale = deviceConfig.fontScale,
         ).setPhoneOrientation(deviceConfig.orientation),
-        showSystemUi = false,
         supportsRtl = true, // needed for "ar" locale
         theme = deviceConfig.theme,
         renderingMode = SessionParams.RenderingMode.V_SCROLL,

--- a/recyclerviewscreen/roborazzi/build.gradle
+++ b/recyclerviewscreen/roborazzi/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.recyclerviewscreen.roborazzi'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -54,6 +52,7 @@ dependencies {
 
     testImplementation "org.robolectric:robolectric:4.10.3"
     testImplementation "io.github.takahirom.roborazzi:roborazzi:1.4.0-alpha-5"
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta03'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0-beta03'
+
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta04'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.0.0-beta04'
 }

--- a/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/accessibility/AccessibilityTest.kt
+++ b/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/accessibility/AccessibilityTest.kt
@@ -56,7 +56,7 @@ class AccessibilityTest {
     @GraphicsMode(GraphicsMode.Mode.NATIVE)
     @Config(sdk = [30])
     @Test
-    fun snapMemoriseViewHolderWithAccessibility() {
+    fun snapMemoriseVHWithAccessibility() {
         val activity = activityScenarioForViewRule.activity
         val layout = activityScenarioForViewRule.inflateAndWaitForIdle(R.layout.memorise_row)
 
@@ -81,7 +81,7 @@ class AccessibilityTest {
     @GraphicsMode(GraphicsMode.Mode.NATIVE)
     @Config(sdk = [30])
     @Test
-    fun snapTrainingViewHolderWithAccessibility() {
+    fun snapTrainingVHWithAccessibility() {
         val layout = activityScenarioForViewRule.inflateAndWaitForIdle(R.layout.training_row)
 
         val viewHolder = waitForMeasuredViewHolder {

--- a/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/recyclerview/FullRecyclerViewTest.kt
+++ b/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/recyclerview/FullRecyclerViewTest.kt
@@ -4,7 +4,6 @@ import android.view.View
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.R
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.mvvm.LanguageTrainingFragment
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.roborazzi.utils.filePath
-import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.roborazzi.utils.drawFullScrollableToBitmap
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Rule
 import org.junit.Test
@@ -15,6 +14,7 @@ import org.robolectric.annotation.GraphicsMode
 import org.robolectric.annotation.GraphicsMode.Mode.NATIVE
 import sergio.sastre.uitesting.robolectric.config.screen.DeviceScreen.Phone.PIXEL_XL
 import sergio.sastre.uitesting.robolectric.fragmentscenario.robolectricFragmentScenarioConfiguratorRule
+import sergio.sastre.uitesting.utils.utils.drawFullScrollableToBitmap
 
 /**
  * Execute the command below to run only RecyclerViewTests

--- a/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/utils/TestUtils.kt
+++ b/recyclerviewscreen/roborazzi/src/test/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/roborazzi/utils/TestUtils.kt
@@ -1,10 +1,6 @@
 package com.example.road.to.effective.snapshot.testing.recyclerviewscreen.roborazzi.utils
 
 import com.github.takahirom.roborazzi.RoborazziOptions
-import android.graphics.Bitmap
-import android.view.View
-import androidx.core.view.drawToBitmap
-import sergio.sastre.uitesting.utils.utils.waitForMeasuredView
 import java.io.File
 
 fun filePath(name: String): String {
@@ -12,9 +8,6 @@ fun filePath(name: String): String {
     val file = File("$path/src/test", "$name.png")
     return file.path
 }
-
-fun View.drawFullScrollableToBitmap(): Bitmap =
-    waitForMeasuredView { this }.drawToBitmap()
 
 val roborazziAccessibilityOptions: RoborazziOptions =
     RoborazziOptions(

--- a/recyclerviewscreen/shot/build.gradle
+++ b/recyclerviewscreen/shot/build.gradle
@@ -6,14 +6,12 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.recyclerviewscreen.shot'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }
@@ -60,7 +58,7 @@ dependencies {
     androidTestImplementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.1'
 
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.8'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta03'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.0.0-beta04'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/activity/LanguageTrainingActivityWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/activity/LanguageTrainingActivityWithParameterizedRunnerTest.kt
@@ -17,6 +17,9 @@ import sergio.sastre.uitesting.utils.activityscenario.activityScenarioForActivit
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/activity/LanguageTrainingActivityWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/activity/LanguageTrainingActivityWithTestParameterInjectorTest.kt
@@ -19,6 +19,9 @@ import sergio.sastre.uitesting.utils.activityscenario.activityScenarioForActivit
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ActivityTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/LanguageTrainingActivityToBitmapTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/LanguageTrainingActivityToBitmapTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/LanguageTrainingFragmentToBitmapTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/LanguageTrainingFragmentToBitmapTest.kt
@@ -20,6 +20,9 @@ import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/MemoriseViewHolderToBitmapTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/bitmap/MemoriseViewHolderToBitmapTest.kt
@@ -25,6 +25,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.BitmapTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/fragment/LanguageTrainingFragmentWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/fragment/LanguageTrainingFragmentWithParameterizedRunnerTest.kt
@@ -17,6 +17,9 @@ import org.junit.runners.Parameterized
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/fragment/LanguageTrainingFragmentWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/fragment/LanguageTrainingFragmentWithTestParameterInjectorTest.kt
@@ -19,6 +19,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfigurat
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.FragmentTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/recyclerview/FullRecyclerViewTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/recyclerview/FullRecyclerViewTest.kt
@@ -3,12 +3,12 @@ package com.example.road.to.effective.snapshot.testing.recyclerviewscreen.shot.r
 import android.view.View
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.R
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.mvvm.LanguageTrainingFragment
-import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.shot.utils.drawFullScrollableToBitmap
 import com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest
 import com.karumi.shot.ScreenshotTest
 import org.junit.Rule
 import org.junit.Test
 import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfiguratorRule
+import sergio.sastre.uitesting.utils.utils.drawFullScrollableToBitmap
 
 /**
  * Execute the command below to run only RecyclerViewTests
@@ -16,6 +16,9 @@ import sergio.sastre.uitesting.utils.fragmentscenario.fragmentScenarioConfigurat
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.RecyclerViewTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 class FullRecyclerViewTest : ScreenshotTest {
 

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/utils/TestUtils.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/utils/TestUtils.kt
@@ -1,9 +1,0 @@
-package com.example.road.to.effective.snapshot.testing.recyclerviewscreen.shot.utils
-
-import android.graphics.Bitmap
-import android.view.View
-import androidx.core.view.drawToBitmap
-import sergio.sastre.uitesting.utils.utils.waitForMeasuredView
-
-fun View.drawFullScrollableToBitmap(): Bitmap =
-    waitForMeasuredView { this }.drawToBitmap()

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/MemoriseViewHolderTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/MemoriseViewHolderTest.kt
@@ -26,6 +26,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/parameterized/TrainingViewHolderWithParameterizedRunnerTest.kt
@@ -20,6 +20,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
+++ b/recyclerviewscreen/shot/src/androidTest/java/com/example/road/to/effective/snapshot/testing/recyclerviewscreen/shot/viewholder/parameterized/TrainingViewHolderWithTestParameterInjectorTest.kt
@@ -21,6 +21,9 @@ import sergio.sastre.uitesting.utils.utils.waitForMeasuredViewHolder
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest -Precord
  * 2. Verify:
  *    ./gradlew :recyclerviewscreen:shot:executeScreenshotTest -Pandroid.testInstrumentationRunnerArguments.annotation=com.example.road.to.effective.snapshot.testing.testannotations.ViewHolderTest
+ *
+ * To run them using Android Orchestrator, add the following at the end of the command:
+ * -PuseOrchestrator
  */
 
 /**

--- a/testannotations/build.gradle
+++ b/testannotations/build.gradle
@@ -5,13 +5,11 @@ plugins {
 
 android {
     namespace 'com.example.road.to.effective.snapshot.testing.testannotations'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Update to AGP 8.x, required updates
- Shot 6.0.0
- Paparazzi 1.3.1

Other upgrades
- Roborazzi 1.4.0-alpha-4