### PR TITLE
Recyclerview-preview tests: fix Dropshots test failing on api 29+

### DIFF
--- a/recyclerviewscreen-previews/dropshots/build.gradle
+++ b/recyclerviewscreen-previews/dropshots/build.gradle
@@ -11,6 +11,8 @@ android {
 
     defaultConfig {
         minSdk 23
+        targetSdk 35
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
@@ -121,7 +121,10 @@ class DropshotsComposePreviewTests(
 
         dropshots.assertSnapshot(
             bitmap = view.drawToBitmapWithElevation(),
-            name = AndroidPreviewScreenshotIdBuilder(preview).build()
+            filePath = preview.declaringClass,
+            name = AndroidPreviewScreenshotIdBuilder(preview)
+                .ignoreClassName()
+                .build()
         )
     }
 }


### PR DESCRIPTION
Add target sdk 35 + avoid super long file names in dropshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Android target SDK version to 35 in the build configuration.

- **Tests**
  - Modified snapshot test logic to change how snapshot files are named and stored, improving clarity and organization of test outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->