### PR TITLE
Feature/update android UI testing utils 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ examples written with different screenshot testing libraries for a better compar
 These examples include tests for screens like the one above (module `:recyclerviewscreen`)
 
 > **Warning**</br>
-> It is configured with AGP 9.0.0, so it requires Android Studio Narwahl or higher!
+> It is configured with AGP 9.0.0, so it requires Android Studio Panda or higher and Java 21!
 
 ## Awards
 
@@ -102,7 +102,7 @@ In order to do that, it contains the same/similar examples but written with diff
 It also contains examples of **Cross-Library Screenshot Tests**: *the very same screenshot tests
 running with multiple libraries, namely: Paparazzi, Roborazzi, Shot, Dropshots & Android-Testify*.
 For that it
-uses [Android UI Testing Utils 2.9.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
+uses [Android UI Testing Utils 2.10.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
 
 You can read more about it in this blog post series:
 
@@ -170,15 +170,15 @@ screenshot tests.
 
 ### Library Versions used in this repo
 
-| Library | Version |
-| ------- | ------- |
-| Compose Preview Screenshot Testing tool | 0.0.1-alpha15 |
-| Paparazzi | 2.0.0-alpha02 |
-| Roborazzi | 1.60.0 |
-| Dropshots | 0.6.0 |
-| Shot | 6.1.0 |
-| Android-testify | 5.0.2 |
-| AndroidUiTestingUtils | 2.9.0 |
+| Library | Version       |
+| ------- |---------------|
+| Compose Preview Screenshot Testing tool | 0.0.1-alpha16 |
+| Paparazzi | 2.0.0-alpha04 |
+| Roborazzi | 1.70.0        |
+| Dropshots | 0.6.0         |
+| Shot | 6.1.0         |
+| Android-testify | 5.0.2         |
+| AndroidUiTestingUtils | 2.10.0        |
 
 For screenshot testing, 2 tasks are required:
 
@@ -419,7 +419,7 @@ to `:recyclerviewscreen` and `:dialogs`
 > `./gradlew :lazycolumnscreen:crosslibrary:copyScreenshots -Pdevices=pixel3api30`:
 
 To enable cross-library screenshot testing, it
-uses [Android UI Testing Utils 2.9.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
+uses [Android UI Testing Utils 2.10.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
 
 ## Parameterized Screenshot Tests
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:2.9.5"
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.foundation:foundation-layout"

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath 'com.dropbox.dropshots:dropshots-gradle-plugin:0.6.0'
         classpath 'io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.70.0'
         classpath 'dev.testify:dev.testify.gradle.plugin:5.0.2'
-        classpath 'com.android.compose.screenshot:screenshot-test-gradle-plugin:0.0.1-alpha15'
+        classpath 'com.android.compose.screenshot:screenshot-test-gradle-plugin:0.0.1-alpha16'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,10 @@ buildscript {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.10'
 
         // screenshot testing plugins
-        classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:2.0.0-alpha02'
+        classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:2.0.0-alpha04'
         classpath 'com.karumi:shot:6.1.0'
         classpath 'com.dropbox.dropshots:dropshots-gradle-plugin:0.6.0'
-        classpath 'io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.60.0'
+        classpath 'io.github.takahirom.roborazzi:roborazzi-gradle-plugin:1.70.0'
         classpath 'dev.testify:dev.testify.gradle.plugin:5.0.2'
         classpath 'com.android.compose.screenshot:screenshot-test-gradle-plugin:0.0.1-alpha15'
 

--- a/dialogs/android-testify/build.gradle
+++ b/dialogs/android-testify/build.gradle
@@ -100,10 +100,10 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
 
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 

--- a/dialogs/crosslibrary/build.gradle
+++ b/dialogs/crosslibrary/build.gradle
@@ -132,20 +132,20 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
 
     // for Gradle Managed Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/dialogs/dropshots/build.gradle
+++ b/dialogs/dropshots/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     implementation project(':testannotations')
 
     androidTestImplementation('androidx.test:rules:1.7.0')
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/dialogs/paparazzi/build.gradle
+++ b/dialogs/paparazzi/build.gradle
@@ -56,10 +56,10 @@ android {
 dependencies {
     implementation project(':dialogs')
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 
     // Jetpack Compose required for Accessibility tests...
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.ui:ui"
 }

--- a/dialogs/roborazzi/build.gradle
+++ b/dialogs/roborazzi/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation project(':dialogs')
 
     testImplementation 'org.robolectric:robolectric:4.16.1'
-    testImplementation 'io.github.takahirom.roborazzi:roborazzi:1.60.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi:1.70.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
 }

--- a/dialogs/shot+roborazzi/build.gradle
+++ b/dialogs/shot+roborazzi/build.gradle
@@ -88,13 +88,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
     // Support for Shot
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
 
     // Support for Roborazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
 }

--- a/dialogs/shot/build.gradle
+++ b/dialogs/shot/build.gradle
@@ -59,8 +59,8 @@ dependencies {
     androidTestImplementation ('org.lsposed.hiddenapibypass:hiddenapibypass:6.1') {
         because("otherwise it does not print the dialog")
     }
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/lazycolumnscreen-previews/build.gradle
+++ b/lazycolumnscreen-previews/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.17.0'
 
     // Jetpack Compose
-    screenshotTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    screenshotTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
 }

--- a/lazycolumnscreen-previews/compose-screenshot/build.gradle
+++ b/lazycolumnscreen-previews/compose-screenshot/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     screenshotTestImplementation project(":lazycolumnscreen")
 
     // Jetpack Compose
-    screenshotTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    screenshotTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
-    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha11'
+    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha15'
 }

--- a/lazycolumnscreen-previews/compose-screenshot/build.gradle
+++ b/lazycolumnscreen-previews/compose-screenshot/build.gradle
@@ -41,9 +41,6 @@ android {
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
 
     testOptions {
-        screenshotTests {
-            imageDifferenceThreshold = 0.0001f // 0.01%
-        }
         targetSdk 36
     }
     lint {
@@ -58,5 +55,5 @@ dependencies {
     // Jetpack Compose
     screenshotTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
-    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha15'
+    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha16'
 }

--- a/lazycolumnscreen-previews/paparazzi/build.gradle
+++ b/lazycolumnscreen-previews/paparazzi/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation project(':lazycolumnscreen')
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -70,6 +70,6 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview"
     debugImplementation "androidx.compose.ui:ui-test-manifest"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/lazycolumnscreen-previews/roborazzi/build.gradle
+++ b/lazycolumnscreen-previews/roborazzi/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation project(':lazycolumnscreen')
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.05.01')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -73,8 +73,8 @@ dependencies {
 
     testImplementation "org.robolectric:robolectric:4.16.1"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.60.0'
-    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:1.60.0'
-    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.70.0'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:1.70.0'
+    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/lazycolumnscreen/android-testify+paparazzi/build.gradle
+++ b/lazycolumnscreen/android-testify+paparazzi/build.gradle
@@ -116,17 +116,17 @@ dependencies {
     implementation project(':testannotations')
 
     // Jetpack Compose
-    debugImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    debugImplementation platform('androidx.compose:compose-bom:2026.06.01')
     debugImplementation "androidx.compose.material:material"
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
     // Support for Android-Testify
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
 
     // Support for Paparazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
 
     // for Gradle Managed Devices
     androidTestUtil "androidx.test.services:test-services:1.6.0"

--- a/lazycolumnscreen/android-testify/build.gradle
+++ b/lazycolumnscreen/android-testify/build.gradle
@@ -111,15 +111,15 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.9.5'
 
     // Jetpack Compose
-    androidTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     androidTestImplementation 'androidx.compose.material:material'
 
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
     androidTestUtil 'androidx.test.services:test-services:1.6.0'

--- a/lazycolumnscreen/build.gradle
+++ b/lazycolumnscreen/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:2.9.5"
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.foundation:foundation-layout"

--- a/lazycolumnscreen/crosslibrary/build.gradle
+++ b/lazycolumnscreen/crosslibrary/build.gradle
@@ -136,24 +136,24 @@ dependencies {
     implementation project(':testannotations')
 
     // Jetpack Compose
-    debugImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    debugImplementation platform('androidx.compose:compose-bom:2026.06.01')
     debugImplementation "androidx.compose.material:material"
 
     // screenshot libs
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
 
     // for Gradle Managed Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/lazycolumnscreen/dropshots/build.gradle
+++ b/lazycolumnscreen/dropshots/build.gradle
@@ -60,12 +60,12 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:2.9.5"
 
     // Jetpack Compose
-    androidTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     androidTestImplementation "androidx.compose.material:material"
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/lazycolumnscreen/paparazzi/build.gradle
+++ b/lazycolumnscreen/paparazzi/build.gradle
@@ -58,8 +58,8 @@ dependencies {
     implementation project(':lazycolumnscreen')
 
     // Jetpack Compose
-    testImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    testImplementation platform('androidx.compose:compose-bom:2026.06.01')
     testImplementation "androidx.compose.material:material"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 }

--- a/lazycolumnscreen/roborazzi/build.gradle
+++ b/lazycolumnscreen/roborazzi/build.gradle
@@ -71,11 +71,11 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:2.9.5"
 
     // Jetpack Compose
-    testImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    testImplementation platform('androidx.compose:compose-bom:2026.06.01')
     testImplementation "androidx.compose.material:material"
 
     testImplementation "org.robolectric:robolectric:4.16.1"
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0'
 }

--- a/lazycolumnscreen/shot/build.gradle
+++ b/lazycolumnscreen/shot/build.gradle
@@ -68,11 +68,11 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.9.5'
 
     // Jetpack Compose
-    androidTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    androidTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     androidTestImplementation "androidx.compose.material:material"
 
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/recyclerviewscreen-previews/android-testify/build.gradle
+++ b/recyclerviewscreen-previews/android-testify/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -123,10 +123,10 @@ dependencies {
     androidTestImplementation ('androidx.navigation:navigation-compose:2.9.5') {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0'
-    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
+    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 

--- a/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
@@ -34,9 +34,10 @@ import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.UiMode
 import sergio.sastre.uitesting.utils.testrules.animations.DisableAnimationsRule
 import sergio.sastre.uitesting.utils.testrules.systemui.NavigationConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.StatusBarConfig
 import sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule
 import sergio.sastre.uitesting.utils.testrules.systemui.navigation.Navigation
-import sergio.sastre.uitesting.utils.utils.drawFullScreenToBitmap
+import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.ClockTime
 import snapshot.testing.recyclerview_previews.android_testify.utils.AndroidTestifyConfig
 import sergio.sastre.uitesting.utils.common.Orientation as ComposableConfigOrientation
 
@@ -88,7 +89,10 @@ object SystemUiPreviewRule {
                 GESTURE -> Navigation.GESTURAL
                 null -> Navigation.GESTURAL
             }
-        return SystemUiTestRule(navigationConfig = NavigationConfig(mode = navigation))
+        return SystemUiTestRule(
+            navigationConfig = NavigationConfig(mode = navigation),
+            statusBarConfig = StatusBarConfig(clockTime = ClockTime.from("10:00"))
+        )
     }
 }
 
@@ -109,8 +113,15 @@ object ActivityScenarioForComposablePreviewRule {
         val locale =
             preview.previewInfo.locale.removePrefix("b+").replace("+", "-").ifBlank { "en" }
 
+        val showSystemUi = preview.previewInfo.showSystemUi
+        val backgroundColor = when (showSystemUi) {
+            true -> null
+            false -> Color.TRANSPARENT
+        }
+
         return ActivityScenarioForComposableRule(
-            backgroundColor = Color.TRANSPARENT,
+            backgroundColor = backgroundColor,
+            showStatusBar = showSystemUi,
             config = ComposableConfigItem(
                 uiMode = uiMode,
                 fontSize = FontSizeScale.Value(preview.previewInfo.fontScale),

--- a/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
@@ -1,7 +1,9 @@
 package snapshot.testing.recyclerview_previews.android_testify
 
+import android.app.Activity
 import android.content.res.Configuration.*
 import android.graphics.Color
+import android.view.View
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.google.testing.junit.testparameterinjector.TestParameter
@@ -17,6 +19,8 @@ import org.junit.runner.RunWith
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.device.DevicePreviewInfoParser
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.BUTTONS
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.GESTURE
 import sergio.sastre.composable.preview.scanner.android.device.domain.Orientation
 import sergio.sastre.composable.preview.scanner.android.screenshotid.AndroidPreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
@@ -29,6 +33,10 @@ import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
 import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.UiMode
 import sergio.sastre.uitesting.utils.testrules.animations.DisableAnimationsRule
+import sergio.sastre.uitesting.utils.testrules.systemui.NavigationConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule
+import sergio.sastre.uitesting.utils.testrules.systemui.navigation.Navigation
+import sergio.sastre.uitesting.utils.utils.drawFullScreenToBitmap
 import snapshot.testing.recyclerview_previews.android_testify.utils.AndroidTestifyConfig
 import sergio.sastre.uitesting.utils.common.Orientation as ComposableConfigOrientation
 
@@ -70,6 +78,18 @@ object ComposablePreviewProvider : TestParameterValuesProvider() {
                 customPreviewsInfoInputStream = getInstrumentation().context.assets.open("custom_previews.json")
             )
             .getPreviews()
+}
+
+object SystemUiPreviewRule {
+    fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): SystemUiTestRule {
+        val navigation =
+            when (DevicePreviewInfoParser.parse(preview.previewInfo.device)?.navigation) {
+                BUTTONS -> Navigation.THREE_BUTTON
+                GESTURE -> Navigation.GESTURAL
+                null -> Navigation.GESTURAL
+            }
+        return SystemUiTestRule(navigationConfig = NavigationConfig(mode = navigation))
+    }
 }
 
 object ActivityScenarioForComposablePreviewRule {
@@ -124,20 +144,30 @@ class AndroidTestifyComposePreviewTests(
     var disableAnimationsRule = DisableAnimationsRule()
 
     @get:Rule(order = 1)
-    val composableRule = ActivityScenarioForComposablePreviewRule.createFor(preview)
+    val systemUiRule = SystemUiPreviewRule.createFor(preview)
 
     @get:Rule(order = 2)
+    val composableRule = ActivityScenarioForComposablePreviewRule.createFor(preview)
+
+    @get:Rule(order = 3)
     var screenshotRule = ScreenshotScenarioPreviewRule.createFor(preview)
 
     @ScreenshotInstrumentation
     @Test
     fun snapPreview() {
+
         screenshotRule
             .withScenario(composableRule.activityScenario)
             .setScreenshotViewProvider {
                 composableRule.setContent { preview() }.composeView
             }
-            .configure { captureMethod = ::pixelCopyCapture }
+            .configure {
+                captureMethod =
+                    when (preview.previewInfo.showSystemUi) {
+                        true -> { _: Activity, _: View? -> systemUiRule.drawFullScreenToBitmap() }
+                        false -> { activity: Activity, targetView: View? -> pixelCopyCapture(activity, targetView) }
+                    }
+            }
             .generateDiffs(true)
             .assertSame(
                 name = AndroidPreviewScreenshotIdBuilder(preview).build()

--- a/recyclerviewscreen-previews/android-testify/src/main/java/snapshot/testing/recyclerview_previews/android_testify/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/android-testify/src/main/java/snapshot/testing/recyclerview_previews/android_testify/PreviewsForScreenshotTests.kt
@@ -25,6 +25,8 @@ import snapshot.testing.recyclerview_previews.shot.utils.initialTrainingItem
 @AndroidTestifyConfig(exactness = 0.85f)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+@Preview(showSystemUi = true) // navigation = gesture
+@Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
 @Composable
 fun MemoriseTextViewHolderPreview() {
 

--- a/recyclerviewscreen-previews/build.gradle
+++ b/recyclerviewscreen-previews/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation project(":recyclerviewscreen")
 
     // Jetpack Compose
-    screenshotTestImplementation platform('androidx.compose:compose-bom:2025.10.00')
+    screenshotTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
 }
 

--- a/recyclerviewscreen-previews/compose-screenshot/build.gradle
+++ b/recyclerviewscreen-previews/compose-screenshot/build.gradle
@@ -39,9 +39,6 @@ android {
     experimentalProperties["android.experimental.enableScreenshotTest"] = true
 
     testOptions {
-        screenshotTests {
-            imageDifferenceThreshold = 0.0001f // 0.01%
-        }
         targetSdk 36
     }
     kotlinOptions {
@@ -50,7 +47,6 @@ android {
     lint {
         targetSdk 36
     }
-
 }
 
 dependencies {
@@ -73,5 +69,5 @@ dependencies {
     screenshotTestImplementation "androidx.compose.ui:ui"
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
     screenshotTestImplementation "androidx.compose.ui:ui-tooling-preview"
-    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha15'
+    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha16'
 }

--- a/recyclerviewscreen-previews/compose-screenshot/build.gradle
+++ b/recyclerviewscreen-previews/compose-screenshot/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     screenshotTestImplementation 'com.google.android.material:material:1.12.0'
 
     // Jetpack Compose
-    screenshotTestImplementation platform('androidx.compose:compose-bom:2025.02.00')
+    screenshotTestImplementation platform('androidx.compose:compose-bom:2026.06.01')
     // Jetpack Compose
     screenshotTestImplementation "androidx.compose.runtime:runtime"
     screenshotTestImplementation "androidx.compose.foundation:foundation-layout"
@@ -73,5 +73,5 @@ dependencies {
     screenshotTestImplementation "androidx.compose.ui:ui"
     screenshotTestImplementation "androidx.compose.ui:ui-tooling"
     screenshotTestImplementation "androidx.compose.ui:ui-tooling-preview"
-    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha11'
+    screenshotTestImplementation 'com.android.tools.screenshot:screenshot-validation-api:0.0.1-alpha15'
 }

--- a/recyclerviewscreen-previews/compose-screenshot/src/screenshotTest/java/snapshot/testing/recyclerview_previews/compose_screenshot/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/compose-screenshot/src/screenshotTest/java/snapshot/testing/recyclerview_previews/compose_screenshot/PreviewsForScreenshotTests.kt
@@ -19,9 +19,6 @@ import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.ui.rows
 import com.example.road.to.effective.snapshot.testing.recyclerviewscreen.R
 
 /**
- * WARNING: Currently this crashes due to a bug in Compose Screenshot Tool:
- * https://issuetracker.google.com/issues/384188032
- *
  * Record: ./gradlew :recyclerviewscreen-previews:compose-screenshot:updateDebugScreenshotTest
  * Verify: ./gradlew :recyclerviewscreen-previews:compose-screenshot:validateDebugScreenshotTest
  *

--- a/recyclerviewscreen-previews/compose-screenshot/src/screenshotTest/java/snapshot/testing/recyclerview_previews/compose_screenshot/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/compose-screenshot/src/screenshotTest/java/snapshot/testing/recyclerview_previews/compose_screenshot/PreviewsForScreenshotTests.kt
@@ -32,6 +32,8 @@ class PreviewsForScreenshotTests {
     @PreviewTest
     @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
     @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+    @Preview(showSystemUi = true) // navigation = gesture
+    @Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
     @Composable
     fun MemoriseTextViewHolderPreview() {
 

--- a/recyclerviewscreen-previews/dropshots/build.gradle
+++ b/recyclerviewscreen-previews/dropshots/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -75,7 +75,7 @@ dependencies {
     androidTestImplementation ('androidx.navigation:navigation-compose:2.9.5') {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
@@ -2,6 +2,7 @@ package snapshot.testing.recyclerview_previews.dropshots
 
 import android.content.res.Configuration.*
 import android.graphics.Color
+import androidx.test.espresso.action.Swiper
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.dropbox.dropshots.Dropshots
@@ -15,6 +16,8 @@ import org.junit.runner.RunWith
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.device.DevicePreviewInfoParser
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.BUTTONS
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.GESTURE
 import sergio.sastre.composable.preview.scanner.android.device.domain.Orientation
 import sergio.sastre.composable.preview.scanner.android.screenshotid.AndroidPreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
@@ -23,6 +26,11 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
 import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
 import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.UiMode
+import sergio.sastre.uitesting.utils.testrules.systemui.NavigationConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.StatusBarConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule
+import sergio.sastre.uitesting.utils.testrules.systemui.navigation.Navigation
+import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.ClockTime
 import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
 import sergio.sastre.uitesting.utils.utils.waitForActivity
 import sergio.sastre.uitesting.utils.utils.waitForComposeView
@@ -59,6 +67,21 @@ object ComposablePreviewProvider : TestParameterValuesProvider() {
             .getPreviews()
 }
 
+object SystemUiPreviewRule {
+    fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): SystemUiTestRule {
+        val navigation =
+            when (DevicePreviewInfoParser.parse(preview.previewInfo.device)?.navigation) {
+                BUTTONS -> Navigation.THREE_BUTTON
+                GESTURE -> Navigation.GESTURAL
+                null -> Navigation.GESTURAL
+            }
+        return SystemUiTestRule(
+            navigationConfig = NavigationConfig(mode = navigation),
+            statusBarConfig = StatusBarConfig(clockTime = ClockTime.from("10:00"))
+        )
+    }
+}
+
 object ActivityScenarioForComposablePreviewRule {
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): ActivityScenarioForComposableRule {
         val uiMode =
@@ -76,8 +99,15 @@ object ActivityScenarioForComposablePreviewRule {
         val locale =
             preview.previewInfo.locale.removePrefix("b+").replace("+", "-").ifBlank { "en" }
 
+        val showSystemUi = preview.previewInfo.showSystemUi
+        val backgroundColor = when (showSystemUi) {
+            true -> null
+            false -> Color.TRANSPARENT
+        }
+
         return ActivityScenarioForComposableRule(
-            backgroundColor = Color.TRANSPARENT,
+            backgroundColor = backgroundColor,
+            showStatusBar = showSystemUi,
             config = ComposableConfigItem(
                 uiMode = uiMode,
                 fontSize = FontSizeScale.Value(preview.previewInfo.fontScale),
@@ -91,8 +121,13 @@ object ActivityScenarioForComposablePreviewRule {
 object DropshotsPreviewRule {
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): Dropshots =
         preview.getAnnotation<DropshotsConfig>()?.let { config ->
-            Dropshots(resultValidator = ThresholdValidator(config.comparisonThreshold))
-        } ?: Dropshots()
+            Dropshots(
+                filenameFunc = { _, name -> name },
+                resultValidator = ThresholdValidator(config.comparisonThreshold)
+            )
+        } ?: Dropshots(
+            filenameFunc = { _, name -> name },
+        )
 }
 
 /**
@@ -106,10 +141,13 @@ class DropshotsComposePreviewTests(
     @TestParameter(valuesProvider = ComposablePreviewProvider::class)
     val preview: ComposablePreview<AndroidPreviewInfo>,
 ) {
-    @get:Rule
+    @get:Rule(order = 0)
     val dropshots = DropshotsPreviewRule.createFor(preview)
 
-    @get:Rule
+    @get:Rule(order = 1)
+    val systemUiRule = SystemUiPreviewRule.createFor(preview)
+
+    @get:Rule(order = 2)
     val composableRule = ActivityScenarioForComposablePreviewRule.createFor(preview)
 
     @Test
@@ -119,8 +157,13 @@ class DropshotsComposePreviewTests(
             .waitForActivity()
             .waitForComposeView()
 
+        val bitmap = when (preview.previewInfo.showSystemUi) {
+            true -> systemUiRule.drawFullScreenToBitmap()
+            false -> view.drawToBitmapWithElevation()
+        }
+
         dropshots.assertSnapshot(
-            bitmap = view.drawToBitmapWithElevation(),
+            bitmap = bitmap,
             filePath = preview.declaringClass,
             name = AndroidPreviewScreenshotIdBuilder(preview)
                 .ignoreClassName()

--- a/recyclerviewscreen-previews/dropshots/src/main/java/snapshot/testing/recyclerview_previews/dropshots/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/dropshots/src/main/java/snapshot/testing/recyclerview_previews/dropshots/PreviewsForScreenshotTests.kt
@@ -25,6 +25,8 @@ import snapshot.testing.recyclerview_previews.shot.utils.initialTrainingItem
 @DropshotsConfig(comparisonThreshold = 0.85f)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+@Preview(showSystemUi = true) // navigation = gesture
+@Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
 @Composable
 fun MemoriseTextViewHolderPreview() {
 
@@ -80,9 +82,9 @@ fun TrainingViewHolderPreview(
             viewHolder.bind(
                 item = initialTrainingItem,
                 languageClickedListener =
-                TrainingPreviewInteractionListener(oldTrainingItem) { newTrainingItemPayload ->
-                    viewHolder.update(newTrainingItemPayload)
-                }
+                    TrainingPreviewInteractionListener(oldTrainingItem) { newTrainingItemPayload ->
+                        viewHolder.update(newTrainingItemPayload)
+                    }
             )
 
             viewHolder.itemView

--- a/recyclerviewscreen-previews/paparazzi/build.gradle
+++ b/recyclerviewscreen-previews/paparazzi/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -65,6 +65,6 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling"
     implementation "androidx.compose.ui:ui-tooling-preview"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/paparazzi/src/main/java/snapshot/testing/recyclerview_previews/paparazzi/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/paparazzi/src/main/java/snapshot/testing/recyclerview_previews/paparazzi/PreviewsForScreenshotTests.kt
@@ -25,6 +25,8 @@ import snapshot.testing.recyclerview_previews.paparazzi.utils.initialTrainingIte
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+@Preview(showSystemUi = true) // navigation = gesture
+@Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
 @Composable
 fun MemoriseTextViewHolderPreview() {
 

--- a/recyclerviewscreen-previews/roborazzi/build.gradle
+++ b/recyclerviewscreen-previews/roborazzi/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -76,8 +76,8 @@ dependencies {
 
     testImplementation "org.robolectric:robolectric:4.16.1"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:1.60.0'
-    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.60.0'
-    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support:1.70.0'
+    testImplementation 'io.github.takahirom.roborazzi:roborazzi-compose:1.70.0'
+    testImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/roborazzi/src/main/java/snapshot/testing/recyclerview_previews/roborazzi/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/roborazzi/src/main/java/snapshot/testing/recyclerview_previews/roborazzi/PreviewsForScreenshotTests.kt
@@ -24,6 +24,8 @@ import snapshot.testing.recyclerview_previews.roborazzi.utils.initialTrainingIte
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+@Preview(showSystemUi = true) // navigation = gesture
+@Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
 @Composable
 fun MemoriseTextViewHolderPreview() {
 

--- a/recyclerviewscreen-previews/shot/build.gradle
+++ b/recyclerviewscreen-previews/shot/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     // Jetpack Compose
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.foundation:foundation-layout"
     implementation "androidx.compose.material:material"
@@ -78,7 +78,7 @@ dependencies {
     androidTestImplementation('androidx.navigation:navigation-compose:2.9.5') {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/shot/src/androidTest/java/snapshot/testing/recyclerview_previews/shot/ShotComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/shot/src/androidTest/java/snapshot/testing/recyclerview_previews/shot/ShotComposePreviewTests.kt
@@ -24,6 +24,7 @@ import sergio.sastre.uitesting.utils.common.UiMode
 import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
 import sergio.sastre.uitesting.utils.utils.waitForActivity
 import sergio.sastre.uitesting.utils.utils.waitForComposeView
+import snapshot.testing.recyclerview_previews.shot.utils.SystemUiPreviewRule
 import snapshot.testing.recyclerview_previews.shot.utils.setContent
 import sergio.sastre.uitesting.utils.common.Orientation as ComposableConfigOrientation
 
@@ -96,7 +97,9 @@ class ShotComposePreviewTests(
     val preview: ComposablePreview<AndroidPreviewInfo>,
 ) : ScreenshotTest {
 
-    @get:Rule
+    @get:Rule(order = 0)
+    val systemUiRule = SystemUiPreviewRule.createFor(preview)
+    @get:Rule(order = 1)
     val composableRule = ActivityScenarioForComposablePreviewRule.createFor(preview)
 
     @Test
@@ -106,8 +109,13 @@ class ShotComposePreviewTests(
             .waitForActivity()
             .waitForComposeView()
 
+        val bitmap = when (preview.previewInfo.showSystemUi) {
+            true -> systemUiRule.drawFullScreenToBitmap()
+            false -> view.drawToBitmapWithElevation()
+        }
+
         compareScreenshot(
-            bitmap = view.drawToBitmapWithElevation(),
+            bitmap = bitmap,
             name = AndroidPreviewScreenshotIdBuilder(preview).build()
         )
     }

--- a/recyclerviewscreen-previews/shot/src/androidTest/java/snapshot/testing/recyclerview_previews/shot/ShotComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/shot/src/androidTest/java/snapshot/testing/recyclerview_previews/shot/ShotComposePreviewTests.kt
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith
 import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
 import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
 import sergio.sastre.composable.preview.scanner.android.device.DevicePreviewInfoParser
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.BUTTONS
+import sergio.sastre.composable.preview.scanner.android.device.domain.Navigation.GESTURE
 import sergio.sastre.composable.preview.scanner.android.device.domain.Orientation
 import sergio.sastre.composable.preview.scanner.android.screenshotid.AndroidPreviewScreenshotIdBuilder
 import sergio.sastre.composable.preview.scanner.core.preview.ComposablePreview
@@ -21,10 +23,14 @@ import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposa
 import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
 import sergio.sastre.uitesting.utils.common.FontSizeScale
 import sergio.sastre.uitesting.utils.common.UiMode
+import sergio.sastre.uitesting.utils.testrules.systemui.NavigationConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.StatusBarConfig
+import sergio.sastre.uitesting.utils.testrules.systemui.SystemUiTestRule
+import sergio.sastre.uitesting.utils.testrules.systemui.navigation.Navigation
+import sergio.sastre.uitesting.utils.testrules.systemui.statusbar.ClockTime
 import sergio.sastre.uitesting.utils.utils.drawToBitmapWithElevation
 import sergio.sastre.uitesting.utils.utils.waitForActivity
 import sergio.sastre.uitesting.utils.utils.waitForComposeView
-import snapshot.testing.recyclerview_previews.shot.utils.SystemUiPreviewRule
 import snapshot.testing.recyclerview_previews.shot.utils.setContent
 import sergio.sastre.uitesting.utils.common.Orientation as ComposableConfigOrientation
 
@@ -57,6 +63,21 @@ object ComposablePreviewProvider : TestParameterValuesProvider() {
             .getPreviews()
 }
 
+object SystemUiPreviewRule {
+    fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): SystemUiTestRule {
+        val navigation =
+            when (DevicePreviewInfoParser.parse(preview.previewInfo.device)?.navigation) {
+                BUTTONS -> Navigation.THREE_BUTTON
+                GESTURE -> Navigation.GESTURAL
+                null -> Navigation.GESTURAL
+            }
+        return SystemUiTestRule(
+            navigationConfig = NavigationConfig(mode = navigation),
+            statusBarConfig = StatusBarConfig(clockTime = ClockTime.from("10:00"))
+        )
+    }
+}
+
 object ActivityScenarioForComposablePreviewRule {
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): ActivityScenarioForComposableRule {
         val uiMode =
@@ -73,8 +94,14 @@ object ActivityScenarioForComposablePreviewRule {
 
         val locale = preview.previewInfo.locale.removePrefix("b+").replace("+","-").ifBlank { "en" }
 
+        val showSystemUi = preview.previewInfo.showSystemUi
+        val backgroundColor = when (showSystemUi) {
+            true -> null
+            false -> Color.TRANSPARENT
+        }
         return ActivityScenarioForComposableRule(
-            backgroundColor = Color.TRANSPARENT,
+            backgroundColor = backgroundColor,
+            showStatusBar = showSystemUi,
             config = ComposableConfigItem(
                 uiMode = uiMode,
                 fontSize = FontSizeScale.Value(preview.previewInfo.fontScale),

--- a/recyclerviewscreen-previews/shot/src/main/java/snapshot/testing/recyclerview_previews/shot/PreviewsForScreenshotTests.kt
+++ b/recyclerviewscreen-previews/shot/src/main/java/snapshot/testing/recyclerview_previews/shot/PreviewsForScreenshotTests.kt
@@ -23,6 +23,8 @@ import snapshot.testing.recyclerview_previews.shot.utils.initialTrainingItem
 
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 31)
+@Preview(showSystemUi = true) // navigation = gesture
+@Preview(showSystemUi = true, device = "spec:parent=pixel_5, orientation=landscape, navigation=buttons")
 @Composable
 fun MemoriseTextViewHolderPreview() {
 

--- a/recyclerviewscreen/android-testify/build.gradle
+++ b/recyclerviewscreen/android-testify/build.gradle
@@ -108,11 +108,11 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
 
     // for Gradle Manage Devices
     androidTestUtil 'androidx.test.services:test-services:1.6.0'

--- a/recyclerviewscreen/crosslibrary/build.gradle
+++ b/recyclerviewscreen/crosslibrary/build.gradle
@@ -137,20 +137,20 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
 
     // To support Gradle Manage Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/recyclerviewscreen/dropshots+roborazzi/build.gradle
+++ b/recyclerviewscreen/dropshots+roborazzi/build.gradle
@@ -82,13 +82,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
 
     // Support for Dropshots
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.9.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
 
     // Support for Roborazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.9.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.9.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
 }

--- a/recyclerviewscreen/dropshots/build.gradle
+++ b/recyclerviewscreen/dropshots/build.gradle
@@ -55,8 +55,8 @@ dependencies {
     androidTestImplementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.2'
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/recyclerviewscreen/paparazzi/build.gradle
+++ b/recyclerviewscreen/paparazzi/build.gradle
@@ -61,9 +61,9 @@ dependencies {
     implementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.2'
 
     // Jetpack Compose required for Accessibility tests...
-    implementation platform('androidx.compose:compose-bom:2025.10.00')
+    implementation platform('androidx.compose:compose-bom:2026.06.01')
     implementation "androidx.compose.runtime:runtime"
     implementation "androidx.compose.ui:ui"
 
-    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
+    testImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 }

--- a/recyclerviewscreen/roborazzi/build.gradle
+++ b/recyclerviewscreen/roborazzi/build.gradle
@@ -63,8 +63,8 @@ dependencies {
     implementation project(':recyclerviewscreen')
 
     testImplementation "org.robolectric:robolectric:4.16.1"
-    testImplementation "io.github.takahirom.roborazzi:roborazzi:1.60.0"
+    testImplementation "io.github.takahirom.roborazzi:roborazzi:1.70.0"
 
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.9.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
 }

--- a/recyclerviewscreen/shot/build.gradle
+++ b/recyclerviewscreen/shot/build.gradle
@@ -62,8 +62,8 @@ dependencies {
 
     androidTestImplementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.2'
 
-    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.19'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.9.0'
+    androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }


### PR DESCRIPTION
# Version updates!
- AndroidUiTestingUtils 2.10.0
- Paparazzi 2.0.0-alpha04
- Roborazzi 1.70.0
- Compose Preview Screenshot Testing 0.0.1-alpha16

# New
- Shot, Dropshots & Android-Testify recyclerview-preview tests support ‘showSystemUi’ and ‘navigation’ properties

# Bugfixes
These library updates also come with some bugfixes
- Paparazzi tests crashing running due to Paparazzi/Compose/Java version incompatibilities
- Paparazzi CrossLibrary screenshot tests crashing due to DropshotsConfig
- Compose Preview Screenshot Test for recyclerview-previews crashing