### PR TITLE
Feature/fix android testify and system UI test rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In order to do that, it contains the same/similar examples but written with diff
 It also contains examples of **Cross-Library Screenshot Tests**: *the very same screenshot tests
 running with multiple libraries, namely: Paparazzi, Roborazzi, Shot, Dropshots & Android-Testify*.
 For that it
-uses [Android UI Testing Utils 2.10.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
+uses [Android UI Testing Utils 2.10.1](https://github.com/sergio-sastre/AndroidUiTestingUtils)
 
 You can read more about it in this blog post series:
 
@@ -178,7 +178,7 @@ screenshot tests.
 | Dropshots | 0.6.0         |
 | Shot | 6.1.0         |
 | Android-testify | 5.0.2         |
-| AndroidUiTestingUtils | 2.10.0        |
+| AndroidUiTestingUtils | 2.10.1        |
 
 For screenshot testing, 2 tasks are required:
 
@@ -419,7 +419,7 @@ to `:recyclerviewscreen` and `:dialogs`
 > `./gradlew :lazycolumnscreen:crosslibrary:copyScreenshots -Pdevices=pixel3api30`:
 
 To enable cross-library screenshot testing, it
-uses [Android UI Testing Utils 2.10.0](https://github.com/sergio-sastre/AndroidUiTestingUtils)
+uses [Android UI Testing Utils 2.10.1](https://github.com/sergio-sastre/AndroidUiTestingUtils)
 
 ## Parameterized Screenshot Tests
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
         targetSdk 36
         versionCode 1
         versionName "1.0"

--- a/dialogs/android-testify/build.gradle
+++ b/dialogs/android-testify/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments = [

--- a/dialogs/android-testify/build.gradle
+++ b/dialogs/android-testify/build.gradle
@@ -100,8 +100,8 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1'
 
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
 

--- a/dialogs/build.gradle
+++ b/dialogs/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/crosslibrary/build.gradle
+++ b/dialogs/crosslibrary/build.gradle
@@ -132,20 +132,20 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.1')
 
     // for Gradle Managed Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/dialogs/crosslibrary/build.gradle
+++ b/dialogs/crosslibrary/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         // make gradle constants available in Tests via BuildConfig to make changes consistent
         // among build and test files

--- a/dialogs/dropshots/build.gradle
+++ b/dialogs/dropshots/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
     androidTestImplementation('androidx.test:rules:1.7.0')
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/dialogs/dropshots/build.gradle
+++ b/dialogs/dropshots/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing.dialogs.dropshots"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/paparazzi/build.gradle
+++ b/dialogs/paparazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/roborazzi/build.gradle
+++ b/dialogs/roborazzi/build.gradle
@@ -61,6 +61,6 @@ dependencies {
 
     testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'io.github.takahirom.roborazzi:roborazzi:1.70.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1'
 }

--- a/dialogs/roborazzi/build.gradle
+++ b/dialogs/roborazzi/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/dialogs/shot+roborazzi/build.gradle
+++ b/dialogs/shot+roborazzi/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         // Warning: For Dropshots, replace it with testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"

--- a/dialogs/shot+roborazzi/build.gradle
+++ b/dialogs/shot+roborazzi/build.gradle
@@ -88,13 +88,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
     // Support for Shot
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.1')
 
     // Support for Roborazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.1')
 }

--- a/dialogs/shot/build.gradle
+++ b/dialogs/shot/build.gradle
@@ -60,7 +60,7 @@ dependencies {
         because("otherwise it does not print the dialog")
     }
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/dialogs/shot/build.gradle
+++ b/dialogs/shot/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }

--- a/lazycolumnscreen-previews/build.gradle
+++ b/lazycolumnscreen-previews/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen-previews/compose-screenshot/build.gradle
+++ b/lazycolumnscreen-previews/compose-screenshot/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen-previews/paparazzi/build.gradle
+++ b/lazycolumnscreen-previews/paparazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen-previews/roborazzi/build.gradle
+++ b/lazycolumnscreen-previews/roborazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen/android-testify+paparazzi/build.gradle
+++ b/lazycolumnscreen/android-testify+paparazzi/build.gradle
@@ -119,14 +119,14 @@ dependencies {
     debugImplementation platform('androidx.compose:compose-bom:2026.06.01')
     debugImplementation "androidx.compose.material:material"
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
     // Support for Android-Testify
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1')
 
     // Support for Paparazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.1')
 
     // for Gradle Managed Devices
     androidTestUtil "androidx.test.services:test-services:1.6.0"

--- a/lazycolumnscreen/android-testify+paparazzi/build.gradle
+++ b/lazycolumnscreen/android-testify+paparazzi/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         // Warning: For Shot, replace it with testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/lazycolumnscreen/android-testify/build.gradle
+++ b/lazycolumnscreen/android-testify/build.gradle
@@ -118,8 +118,8 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
     androidTestUtil 'androidx.test.services:test-services:1.6.0'

--- a/lazycolumnscreen/android-testify/build.gradle
+++ b/lazycolumnscreen/android-testify/build.gradle
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments = [

--- a/lazycolumnscreen/build.gradle
+++ b/lazycolumnscreen/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen/crosslibrary/build.gradle
+++ b/lazycolumnscreen/crosslibrary/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         // make gradle constants available in Tests via BuildConfig to make changes consistent
         // among build and test files

--- a/lazycolumnscreen/crosslibrary/build.gradle
+++ b/lazycolumnscreen/crosslibrary/build.gradle
@@ -140,20 +140,20 @@ dependencies {
     debugImplementation "androidx.compose.material:material"
 
     // screenshot libs
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.1')
 
     // for Gradle Managed Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/lazycolumnscreen/dropshots/build.gradle
+++ b/lazycolumnscreen/dropshots/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen/dropshots/build.gradle
+++ b/lazycolumnscreen/dropshots/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/lazycolumnscreen/paparazzi/build.gradle
+++ b/lazycolumnscreen/paparazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen/roborazzi/build.gradle
+++ b/lazycolumnscreen/roborazzi/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     testImplementation "androidx.compose.material:material"
 
     testImplementation "org.robolectric:robolectric:4.16.1"
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1'
 }

--- a/lazycolumnscreen/roborazzi/build.gradle
+++ b/lazycolumnscreen/roborazzi/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/lazycolumnscreen/shot/build.gradle
+++ b/lazycolumnscreen/shot/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     androidTestImplementation "androidx.compose.material:material"
 
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/lazycolumnscreen/shot/build.gradle
+++ b/lazycolumnscreen/shot/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }

--- a/recyclerviewscreen-previews/android-testify/build.gradle
+++ b/recyclerviewscreen-previews/android-testify/build.gradle
@@ -124,8 +124,8 @@ dependencies {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1'
     debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 
     androidTestImplementation 'androidx.test:rules:1.7.0'

--- a/recyclerviewscreen-previews/android-testify/build.gradle
+++ b/recyclerviewscreen-previews/android-testify/build.gradle
@@ -28,7 +28,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments = [

--- a/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/android-testify/src/androidTest/java/snapshot/testing/recyclerview_previews/android_testify/AndroidTestifyComposePreviewTests.kt
@@ -28,6 +28,7 @@ import sergio.sastre.composable.preview.scanner.core.preview.getAnnotation
 import sergio.sastre.uitesting.android_testify.screenshotscenario.assertSame
 import sergio.sastre.uitesting.android_testify.screenshotscenario.generateDiffs
 import sergio.sastre.uitesting.android_testify.screenshotscenario.setContent
+import sergio.sastre.uitesting.android_testify.screenshotscenario.waitForIdleSync
 import sergio.sastre.uitesting.utils.activityscenario.ActivityScenarioForComposableRule
 import sergio.sastre.uitesting.utils.activityscenario.ComposableConfigItem
 import sergio.sastre.uitesting.utils.common.FontSizeScale
@@ -77,8 +78,7 @@ object ComposablePreviewProvider : TestParameterValuesProvider() {
             .scanFile(
                 targetInputStream = getInstrumentation().context.assets.open("scan_result.json"),
                 customPreviewsInfoInputStream = getInstrumentation().context.assets.open("custom_previews.json")
-            )
-            .getPreviews()
+            ).getPreviews()
 }
 
 object SystemUiPreviewRule {
@@ -98,11 +98,10 @@ object SystemUiPreviewRule {
 
 object ActivityScenarioForComposablePreviewRule {
     fun createFor(preview: ComposablePreview<AndroidPreviewInfo>): ActivityScenarioForComposableRule {
-        val uiMode =
-            when (preview.previewInfo.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES) {
-                true -> UiMode.NIGHT
-                false -> UiMode.DAY
-            }
+        val uiMode = when (preview.previewInfo.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES) {
+            true -> UiMode.NIGHT
+            false -> UiMode.DAY
+        }
 
         val orientation =
             when (DevicePreviewInfoParser.parse(preview.previewInfo.device)?.orientation == Orientation.LANDSCAPE) {
@@ -147,8 +146,7 @@ object ScreenshotScenarioPreviewRule {
 @SdkSuppress(minSdkVersion = 24)
 @RunWith(TestParameterInjector::class)
 class AndroidTestifyComposePreviewTests(
-    @TestParameter(valuesProvider = ComposablePreviewProvider::class)
-    val preview: ComposablePreview<AndroidPreviewInfo>,
+    @TestParameter(valuesProvider = ComposablePreviewProvider::class) val preview: ComposablePreview<AndroidPreviewInfo>,
 ) {
 
     @get:Rule(order = 0)
@@ -166,20 +164,18 @@ class AndroidTestifyComposePreviewTests(
     @ScreenshotInstrumentation
     @Test
     fun snapPreview() {
-
         screenshotRule
             .withScenario(composableRule.activityScenario)
             .setScreenshotViewProvider {
                 composableRule.setContent { preview() }.composeView
-            }
-            .configure {
-                captureMethod =
-                    when (preview.previewInfo.showSystemUi) {
-                        true -> { _: Activity, _: View? -> systemUiRule.drawFullScreenToBitmap() }
-                        false -> { activity: Activity, targetView: View? -> pixelCopyCapture(activity, targetView) }
-                    }
+            }.configure {
+                captureMethod = when (preview.previewInfo.showSystemUi) {
+                    true -> { _: Activity, _: View? -> systemUiRule.drawFullScreenToBitmap() }
+                    false -> { activity: Activity, targetView: View? -> pixelCopyCapture(activity, targetView) }
+                }
             }
             .generateDiffs(true)
+            .waitForIdleSync()
             .assertSame(
                 name = AndroidPreviewScreenshotIdBuilder(preview).build()
             )

--- a/recyclerviewscreen-previews/build.gradle
+++ b/recyclerviewscreen-previews/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
         targetSdk 36
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -57,7 +57,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/recyclerviewscreen-previews/compose-screenshot/build.gradle
+++ b/recyclerviewscreen-previews/compose-screenshot/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen-previews/dropshots/build.gradle
+++ b/recyclerviewscreen-previews/dropshots/build.gradle
@@ -76,6 +76,6 @@ dependencies {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
     debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/dropshots/build.gradle
+++ b/recyclerviewscreen-previews/dropshots/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
+++ b/recyclerviewscreen-previews/dropshots/src/androidTest/java/snapshot/testing/recyclerview_previews/dropshots/DropshotsComposePreviewTests.kt
@@ -2,7 +2,6 @@ package snapshot.testing.recyclerview_previews.dropshots
 
 import android.content.res.Configuration.*
 import android.graphics.Color
-import androidx.test.espresso.action.Swiper
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.dropbox.dropshots.Dropshots

--- a/recyclerviewscreen-previews/paparazzi/build.gradle
+++ b/recyclerviewscreen-previews/paparazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen-previews/roborazzi/build.gradle
+++ b/recyclerviewscreen-previews/roborazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen-previews/shot/build.gradle
+++ b/recyclerviewscreen-previews/shot/build.gradle
@@ -79,6 +79,6 @@ dependencies {
         because "The ActivityScenarioRule wants to set a Composable as activity content"
     }
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
     debugImplementation 'io.github.sergio-sastre.ComposablePreviewScanner:android:0.9.1'
 }

--- a/recyclerviewscreen-previews/shot/build.gradle
+++ b/recyclerviewscreen-previews/shot/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }
 

--- a/recyclerviewscreen/android-testify/build.gradle
+++ b/recyclerviewscreen/android-testify/build.gradle
@@ -111,8 +111,8 @@ dependencies {
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1'
 
     // for Gradle Manage Devices
     androidTestUtil 'androidx.test.services:test-services:1.6.0'

--- a/recyclerviewscreen/android-testify/build.gradle
+++ b/recyclerviewscreen/android-testify/build.gradle
@@ -27,7 +27,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments = [

--- a/recyclerviewscreen/build.gradle
+++ b/recyclerviewscreen/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen/crosslibrary/build.gradle
+++ b/recyclerviewscreen/crosslibrary/build.gradle
@@ -137,20 +137,20 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:shot:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.1')
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:android-testify:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.1')
 
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:paparazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-paparazzi:2.10.1')
 
     // To support Gradle Manage Devices
     androidTestUtil('androidx.test.services:test-services:1.6.0')

--- a/recyclerviewscreen/crosslibrary/build.gradle
+++ b/recyclerviewscreen/crosslibrary/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         // make gradle constants available in Tests via BuildConfig to make changes consistent
         // among build and test files

--- a/recyclerviewscreen/dropshots+roborazzi/build.gradle
+++ b/recyclerviewscreen/dropshots+roborazzi/build.gradle
@@ -82,13 +82,13 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.13.0'
 
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1')
 
     // Support for Dropshots
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.0')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:dropshots:2.10.1')
 
     // Support for Roborazzi
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0')
-    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.0')
-    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.0')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1')
+    testImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:roborazzi:2.10.1')
+    debugImplementation('com.github.sergio-sastre.AndroidUiTestingUtils:mapper-roborazzi:2.10.1')
 }

--- a/recyclerviewscreen/dropshots+roborazzi/build.gradle
+++ b/recyclerviewscreen/dropshots+roborazzi/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         // Warning: For Shot, replace it with testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/recyclerviewscreen/dropshots/build.gradle
+++ b/recyclerviewscreen/dropshots/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/recyclerviewscreen/dropshots/build.gradle
+++ b/recyclerviewscreen/dropshots/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen/paparazzi/build.gradle
+++ b/recyclerviewscreen/paparazzi/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen/roborazzi/build.gradle
+++ b/recyclerviewscreen/roborazzi/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/recyclerviewscreen/roborazzi/build.gradle
+++ b/recyclerviewscreen/roborazzi/build.gradle
@@ -65,6 +65,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.16.1"
     testImplementation "io.github.takahirom.roborazzi:roborazzi:1.70.0"
 
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
-    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.0'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
+    testImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:robolectric:2.10.1'
 }

--- a/recyclerviewscreen/shot/build.gradle
+++ b/recyclerviewscreen/shot/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     androidTestImplementation 'com.hannesdorfmann:adapterdelegates4-kotlin-dsl:4.3.2'
 
     androidTestImplementation 'com.google.testparameterinjector:test-parameter-injector:1.22'
-    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.0'
+    androidTestImplementation 'com.github.sergio-sastre.AndroidUiTestingUtils:utils:2.10.1'
 
     androidTestUtil 'androidx.test:orchestrator:1.6.1'
 }

--- a/recyclerviewscreen/shot/build.gradle
+++ b/recyclerviewscreen/shot/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         testApplicationId "com.example.road.to.effective.snapshot.testing"
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
     }

--- a/testannotations/build.gradle
+++ b/testannotations/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 36
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Raised the minimum supported Android API level from 23 to 24 across application, library, preview, and testing modules.

* **Dependency Updates**
  * Upgraded Android UI testing utilities from version 2.10.0 to 2.10.1 across screenshot and instrumentation integrations.

* **Bug Fixes**
  * Improved preview screenshot test synchronization by waiting for the UI to become idle before completing comparisons.

* **Documentation**
  * Updated README references to Android UI Testing Utils 2.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->